### PR TITLE
system/avb_verify: Add upgrade verification that not depends on KV

### DIFF
--- a/verify/avb_main.c
+++ b/verify/avb_main.c
@@ -35,7 +35,7 @@ int main(int argc, char* argv[])
     AvbSlotVerifyFlags flags = 0;
     int ret;
 
-    while ((ret = getopt(argc, argv, "bchiI")) != -1) {
+    while ((ret = getopt(argc, argv, "bchiI:")) != -1) {
         switch (ret) {
         case 'b':
             break;
@@ -51,11 +51,7 @@ int main(int argc, char* argv[])
             break;
         case 'I':
             struct avb_hash_desc_t hash_desc;
-            if (argc - optind < 2) {
-                usage(argv[0]);
-                return 100;
-            }
-            if (!avb_hash_desc(argv[optind + 1], &hash_desc)) {
+            if (!avb_hash_desc(optarg, &hash_desc)) {
                 avb_hash_desc_dump(&hash_desc);
                 return 0;
             }

--- a/verify/avb_main.c
+++ b/verify/avb_main.c
@@ -17,17 +17,40 @@
 #include "avb_verify.h"
 #include <unistd.h>
 
-void usage(const char* progname)
+#define usage(p) usage_line_num(p, __LINE__)
+#define PRINT_VERIFY(o, u, as, ar, p, c) \
+    avb_printf("  %-6s | %-6s | %-8s | %-8s | %-6s | %s\n", o, u, as, ar, p, c)
+
+void usage_line_num(const char* progname, const int line_num)
 {
     avb_printf("Usage: %s [-b] [-c] [-i] <partition> <key> [suffix]\n", progname);
     avb_printf("       %s [-I] <partition>\n", progname);
-    avb_printf("Examples:\n");
-    avb_printf("  1. Boot Verify\n");
+    avb_printf("       %s [-U] <image> <partition> <key>\n", progname);
+
+    avb_printf("\nVerify\n");
+    PRINT_VERIFY("Option", "Update", "Allow", "Allow", "IDX", "Description");
+    PRINT_VERIFY("", "IDX", "Same IDX", "Rollback", "in KV", "");
+    PRINT_VERIFY("----", "----", "----", "----", "----", "----");
+    PRINT_VERIFY("-b", "Y", "Y", "N", "Y", "Boot verification that enabled by default");
+    PRINT_VERIFY("-i", "Y", "Y", "Y", "Y", "Ignore rollback index error during boot verification");
+    PRINT_VERIFY("-c", "N", "N", "N", "Y", "Comparing rollback index to prevent duplicate installation");
+    PRINT_VERIFY("-U", "N", "Y", "N", "N", "Upgrade verify by comparing the rollback index in partition and image");
+
+    avb_printf("\nInfo print\n");
+    avb_printf("  %-4s Show image info\n", "-I");
+    avb_printf("  %-4s Show help\n", "-h");
+
+    avb_printf("\nExamples\n");
+    avb_printf("  -  Boot Verify\n");
     avb_printf("     %s <partition> <key> [suffix]\n", progname);
-    avb_printf("  2. Upgrade Verify\n");
+    avb_printf("  -  Comparing rollback index\n");
     avb_printf("     %s -c <image> <key> [suffix]\n", progname);
-    avb_printf("  3. Image Info\n");
+    avb_printf("  -  Upgrade Verify\n");
+    avb_printf("     %s -U <image> <partition> <key> [suffix]\n", progname);
+    avb_printf("  -  Image Info\n");
     avb_printf("     %s -I <image>\n", progname);
+
+    avb_printf("\nLine num: %d\n", line_num);
 }
 
 int main(int argc, char* argv[])

--- a/verify/avb_main.c
+++ b/verify/avb_main.c
@@ -33,9 +33,10 @@ void usage(const char* progname)
 int main(int argc, char* argv[])
 {
     AvbSlotVerifyFlags flags = 0;
+    const char* image = NULL;
     int ret;
 
-    while ((ret = getopt(argc, argv, "bchiI:")) != -1) {
+    while ((ret = getopt(argc, argv, "bchiI:U:")) != -1) {
         switch (ret) {
         case 'b':
             break;
@@ -57,6 +58,11 @@ int main(int argc, char* argv[])
             }
             return 1;
             break;
+        case 'U':
+            flags |= UTILS_AVB_VERIFY_LOCAL_FLAG_NOKV;
+            image = optarg;
+            g_rollback_index = 0;
+            break;
         default:
             usage(argv[0]);
             return 10;
@@ -72,6 +78,11 @@ int main(int argc, char* argv[])
     ret = avb_verify(argv[optind], argv[optind + 1], argv[optind + 2], flags);
     if (ret != 0)
         avb_printf("%s error %d\n", argv[0], ret);
+    else if (image) {
+        ret = avb_verify(image, argv[optind + 1], argv[optind + 2], flags);
+        if (ret != 0)
+            avb_printf("%s verify %s error %d\n", argv[0], image, ret);
+    }
 
     return ret;
 }

--- a/verify/avb_verify.h
+++ b/verify/avb_verify.h
@@ -23,12 +23,17 @@
 extern "C" {
 #endif
 
+#define UTILS_AVB_VERIFY_LOCAL_FLAG_MASK 0xf000
+#define UTILS_AVB_VERIFY_LOCAL_FLAG_NOKV 0x8000
+
 struct avb_hash_desc_t {
     uint64_t image_size;
     uint8_t hash_algorithm[32]; /* Ref: struct AvbHashDescriptor */
     uint32_t digest_len;
     uint8_t digest[64]; /* Max: sha512 */
 };
+
+extern uint64_t g_rollback_index;
 
 int avb_verify(const char* partition, const char* key, const char* suffix, AvbSlotVerifyFlags flags);
 int avb_hash_desc(const char* full_partition_name, struct avb_hash_desc_t* desc);


### PR DESCRIPTION
## Summary
1. avb_verify: Fix parsing of image info("-I") option
2. **avb_verify: Add upgrade verification that not depends on KV**
3. avb_verify: Add more verification instructions to the help information

More details, please see the commit message.
```
Usage: avb_verify [-b] [-c] [-i] <partition> <key> [suffix]
       avb_verify [-I] <partition>
       avb_verify [-U] <image> <partition> <key>

Verify
  Option | Update | Allow    | Allow    | IDX    | Description
         | IDX    | Same IDX | Rollback | in KV  |
  ----   | ----   | ----     | ----     | ----   | ----
  -b     | Y      | Y        | N        | Y      | Boot verification that enabled by default
  -i     | Y      | Y        | Y        | Y      | Ignore rollback index error during boot verification
  -c     | N      | N        | N        | Y      | Comparing rollback index to prevent duplicate installation
  -U     | N      | Y        | N        | N      | Upgrade verify by comparing the rollback index in partition and image

Info print
  -I   Show image info
  -h   Show help

Examples
  -  Boot Verify
     avb_verify <partition> <key> [suffix]
  -  Comparing rollback index
     avb_verify -c <image> <key> [suffix]
  -  Upgrade Verify
     avb_verify -U <image> <partition> <key> [suffix]
  -  Image Info
     avb_verify -I <image>
```

## Impact
frameworks/system/ota

## Testing
1. Selftest
```bash
#
# Skip same index - PASS
#

$ avb_verify -c image_0 ./key.avb
avb_slot_verify.c:945: ERROR: image_0: Image rollback index is less than the stored rollback index.
avb_verify error 4

$ avb_verify -c image_1 ./key.avb
$ echo $?
0

#
# Prevent downgrade - PASS
#

$ avb_verify -U image_0 image_1 key.avb 
avb_slot_verify.c:945: ERROR: image_0: Image rollback index is less than the stored rollback index.
avb_verify verify image_0 error 4

$ avb_verify -U image_1 image_0 key.avb
$ echo $?
0

#
# Show info - PASS
#

$ avb_verify -I image_0
Image Size       : 9252636 bytes
Hash Algorithm   : sha256
Digest Length    : 32
Digest           : d23a164a7d9f7acc91994280b214ef5cb2419824c1d473e9a4c2e320b33c707b
```
2. CI
