### PR TITLE
ota: Update the OTA upgrade verfication from kv base to AVB

### DIFF
--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -124,11 +124,6 @@ setprop ota.progress.next %d
     fd.write(str)
 
     str = \
-'''setprop ota.version.next `getprop ota.version.current`
-'''
-    fd.write(str)
-
-    str = \
 '''if [ ! -e /ota/%s ]
 then
 ''' % (bin_list[bin_list_cnt - 1])
@@ -329,11 +324,7 @@ setprop ota.progress.next %d
 ''' % (ota_progress_list[0])
     fd.write(str)
 
-    if (args.skip_version_check) :
-        str = \
-'''setprop ota.version.next `getprop ota.version.current`
-'''
-    else :
+    if not args.skip_version_check :
         str = \
 '''set version_current `getprop ro.ota.version`
 
@@ -347,8 +338,7 @@ then
 fi
 
 ''' % (args.version[0], args.version[0], args.otalog)
-
-    fd.write(str)
+        fd.write(str)
     # avoid /dev/<xxx> doesn't exist
     i = 0
     while i < path_cnt:

--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -326,8 +326,7 @@ setprop ota.progress.next %d
 
     i = 0
     while i < path_cnt:
-        if not args.skip_version_check :
-            str = \
+        str = \
 '''
 avb_verify -U /ota/%s %s /etc/key.avb
 if [ $? -ne 0 ]
@@ -478,11 +477,6 @@ if __name__ == "__main__":
                         nargs=1,
                         type=int,
                         default=[0])
-
-    parser.add_argument('--skip_version_check',\
-                        help='skip version check,all version can update this ota.zip',
-                        action='store_true',
-                        default=False)
 
     parser.add_argument("--speedconf",
                         help='''

--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -338,17 +338,6 @@ then
 fi
 ''' % (bin_list[i], path_list[i], args.otalog)
             fd.write(str)
-        # avoid /dev/<xxx> doesn't exist
-        str = \
-'''
-if [ ! -e %s ]
-then
-    echo "%s doesn't exist, will reboot to the old system"%s
-    setprop ota.progress.current -1
-    exit
-fi
-''' % (path_list[i], path_list[i], args.otalog)
-        fd.write(str)
         i += 1
 
     i = 0

--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -332,42 +332,25 @@ setprop ota.progress.next %d
 avb_verify -U /ota/%s %s /etc/key.avb
 if [ $? -ne 0 ]
 then
-    echo "check version failed!"%s
+    echo "check %s version failed!"%s
     setprop ota.progress.current -1
     exit
 fi
-''' % (bin_list[i], path_list[i], args.otalog)
-            fd.write(str)
-        i += 1
+''' % (bin_list[i], path_list[i], bin_list[i], args.otalog)
 
-    i = 0
-    while i < path_cnt:
-        str = 'set ret 0\n'
-        if args.upgrade_verify:
-            for upgrade in args.upgrade_verify:
-                if upgrade == bin_list[i][5:-4]:
-                    logger.info("Enable upgrade verify for %s" % upgrade)
-                    str += 'avb_verify -c /ota/%s /etc/key.avb\n' % bin_list[i]
-                    str += 'set ret $?\n'
-                    break
         str += \
 '''
-if [ $ret -eq 0 ]
+echo "install %s"%s
+time " dd if=/ota/%s of=%s bs=%s verify"
+if [ $? -ne 0 ]
 then
-  echo "install %s"%s
-  time " dd if=/ota/%s of=%s bs=%s verify"
-  if [ $? -ne 0 ]
-  then
-      echo "dd %s failed"%s
-      reboot
-  fi
-else
-  echo "skip %s"
+    echo "dd %s failed"%s
+    reboot
 fi
 setprop ota.progress.current %d
 ''' % (bin_list[i], args.otalog,
        bin_list[i], path_list[i], args.bs,
-       bin_list[i], args.otalog, bin_list[i], ota_progress_list[i])
+       bin_list[i], args.otalog, ota_progress_list[i])
         if i + 1 < path_cnt:
             str += 'setprop ota.progress.next %d\n' % (ota_progress_list[i + 1])
         fd.write(str)

--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -123,25 +123,9 @@ setprop ota.progress.next %d
 ''' % (ota_progress_list[0])
     fd.write(str)
 
-    if (args.skip_version_check) :
-        str = \
+    str = \
 '''setprop ota.version.next `getprop ota.version.current`
 '''
-    else :
-        str = \
-'''set version_current `getprop ro.ota.version`
-
-echo "new version is "%d
-
-if [ %d -lt $version_current ]
-then
-    echo "check version failed!"%s
-    setprop ota.progress.current -1
-    exit
-fi
-
-''' % (args.version[0], args.version[0], args.otalog)
-
     fd.write(str)
 
     str = \

--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -324,24 +324,21 @@ setprop ota.progress.next %d
 ''' % (ota_progress_list[0])
     fd.write(str)
 
-    if not args.skip_version_check :
-        str = \
-'''set version_current `getprop ro.ota.version`
-
-echo "new version is "%d
-
-if [ %d -lt $version_current ]
+    i = 0
+    while i < path_cnt:
+        if not args.skip_version_check :
+            str = \
+'''
+avb_verify -U /ota/%s %s /etc/key.avb
+if [ $? -ne 0 ]
 then
     echo "check version failed!"%s
     setprop ota.progress.current -1
     exit
 fi
-
-''' % (args.version[0], args.version[0], args.otalog)
-        fd.write(str)
-    # avoid /dev/<xxx> doesn't exist
-    i = 0
-    while i < path_cnt:
+''' % (bin_list[i], path_list[i], args.otalog)
+            fd.write(str)
+        # avoid /dev/<xxx> doesn't exist
         str = \
 '''
 if [ ! -e %s ]


### PR DESCRIPTION
## Summary
1. ota: The OTA diff upgrade does not need anti-downgrade
    - The OTA diff upgrade does not need anti-downgrade.
    - The OTA differential package is signed using private key, that means the package is legal, and the old and new version are with the plan.
2. ota: Remove the deprecated ota.version.next and ota.version.current    (**KV base**)
3. ota: Update "version_check"(aka upgrade verifiation, anti-downgrade) to AVB  (**AVB base**)
4. ota: Remove the uncessary exist check for partitions in /dev 
5. ota: Remove the deprecated avb_verify -c upgrade verify    (**KV base**)
6. ota: Remove the skip_version_check option

## Impact
frameworks/system/ota

## Testing
- Diff OTA
```
$ ./gen_ota_zip.py old_ota_imgs ota_imgs --debug --sign

$ cat ota.sh 
set +e
setprop ota.progress.current 30
setprop ota.progress.next 100
setprop ota.version.next `getprop ota.version.current`
if [ ! -e /ota/vela_ap.bin ]
then

    echo "generate vela_ap.bin"
    time "ddelta_apply /dev/ap /data/ota_tmp/ /ota/vela_ap.patch"
    if [ $? -ne 0 ]
    then
        echo "ddelta_apply vela_ap failed"
        setprop ota.progress.current -1
        exit
    fi

    setprop ota.progress.current 100

fi
```
- Full OTA with upgrade verification
```
$ cat ota.sh 
set +e
setprop ota.progress.current 30
setprop ota.progress.next 100

avb_verify -U /ota/vela_ap.bin /dev/ap /etc/key.avb
if [ $? -ne 0 ]
then
    echo "check vela_ap.bin version failed!"
    setprop ota.progress.current -1
    exit
fi

echo "install vela_ap.bin"
time " dd if=/ota/vela_ap.bin of=/dev/ap bs=32768 verify"
if [ $? -ne 0 ]
then
    echo "dd vela_ap.bin failed"
    reboot
fi
setprop ota.progress.current 100
```
