### PR TITLE
avb_verify: Add rollback_index and location info for option "-I"

### DIFF
--- a/verify/avb_verify.c
+++ b/verify/avb_verify.c
@@ -400,6 +400,9 @@ int avb_hash_desc(const char* full_partition_name, struct avb_hash_desc_t* desc)
     avb_vbmeta_image_header_to_host_byte_order((AvbVBMetaImageHeader*)vbmeta_buf,
         &vbmeta_header);
 
+    desc->rollback_index_location = vbmeta_header.rollback_index_location;
+    desc->rollback_index = vbmeta_header.rollback_index;
+
     descriptors = avb_descriptor_get_all(vbmeta_buf, vbmeta_num_read, &num_descriptors);
     if (!avb_descriptor_validate_and_byteswap(descriptors[0], &avb_desc)) {
         avb_error(full_partition_name, ": Descriptor is invalid.\n");
@@ -457,4 +460,6 @@ void avb_hash_desc_dump(const struct avb_hash_desc_t* desc)
         avb_printf("%02" PRIx8 "", desc->digest[i]);
     }
     avb_printf("\n");
+    avb_printf("%-16s : %" PRIu32 "\n", "Rollback Loc", desc->rollback_index_location);
+    avb_printf("%-16s : %" PRIu64 "\n", "Rollback Index", desc->rollback_index);
 }

--- a/verify/avb_verify.h
+++ b/verify/avb_verify.h
@@ -31,6 +31,8 @@ struct avb_hash_desc_t {
     uint8_t hash_algorithm[32]; /* Ref: struct AvbHashDescriptor */
     uint32_t digest_len;
     uint8_t digest[64]; /* Max: sha512 */
+    uint32_t rollback_index_location;
+    uint64_t rollback_index;
 };
 
 extern uint64_t g_rollback_index;


### PR DESCRIPTION
## Summary
avb_verify: Add rollback_index and location info for option "-I"
Make runtime debug eaiser.

## Impact
avb_verify -I

## Testing
```diff
  $ avb_verify -I test.bin
  Image Size       : 693460 bytes
  Hash Algorithm   : sha256
  Digest Length    : 32
  Digest           : 78b2ceced754065f1f21361c6a03258e7a3ea1ba7310182d0d2e0681db55b646
+ Rollback Loc     : 0
+ Rollback Index   : 1
```