### PR TITLE
avb_verify: Remove KVDB related verfications

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -66,21 +66,6 @@ config UTILS_AVB_VERIFY_STACKSIZE
 	int "Stack size of AVB verification tools"
 	default 6144
 
-config UTILS_AVB_VERIFY_ENABLE_DEVICE_LOCK
-	bool "Enable Device Lock"
-	default y
-	depends on KVDB
-
-config UTILS_AVB_VERIFY_ENABLE_PERSISTENT_VALUE
-	bool "Enable Persistent Value"
-	default y
-	depends on KVDB
-
-config UTILS_AVB_VERIFY_ENABLE_ROLLBACK_PROTECTION
-	bool "Enable Rollback Protection"
-	default y
-	depends on KVDB
-
 endif
 
 config UTILS_ZIP_VERIFY

--- a/verify/avb_verify.h
+++ b/verify/avb_verify.h
@@ -23,9 +23,6 @@
 extern "C" {
 #endif
 
-#define UTILS_AVB_VERIFY_LOCAL_FLAG_MASK 0xf000
-#define UTILS_AVB_VERIFY_LOCAL_FLAG_NOKV 0x8000
-
 struct avb_hash_desc_t {
     uint64_t image_size;
     uint8_t hash_algorithm[32]; /* Ref: struct AvbHashDescriptor */
@@ -35,9 +32,15 @@ struct avb_hash_desc_t {
     uint64_t rollback_index;
 };
 
-extern uint64_t g_rollback_index;
+struct avb_params_t {
+    const char* partition;
+    const char* image;
+    const char* key;
+    const char* suffix;
+    AvbSlotVerifyFlags flags;
+};
 
-int avb_verify(const char* partition, const char* key, const char* suffix, AvbSlotVerifyFlags flags);
+int avb_verify(struct avb_params_t* params);
 int avb_hash_desc(const char* full_partition_name, struct avb_hash_desc_t* desc);
 void avb_hash_desc_dump(const struct avb_hash_desc_t* desc);
 


### PR DESCRIPTION
_**WARNING: Has NOT committed to gerrit yet**_
## Summary
It`s unsafe to store values to KVDB.

1. The options "-c" was removed, please use "-U"(upgrade verfication) instead.

    Comparing rollback index to prevent duplicate installation

2. The parameters of INTERNAL used function `avb_verify` was updated:

    -int avb_verify(const char* partition, const char* key, const char* suffix, AvbSlotVerifyFlags flags)
    +int avb_verify(struct avb_params_t* params)

## Impact
frameworks/system/ota/verify/avb_verify

## Testing
```
    dd if=/dev/random of=1MB_1.1 bs=1MB count=1
    ../tools/avb_sign.sh 1MB_1.1 0 -P $(pwd)/1MB -o --dynamic_partition_size -o "--rollback_index_location 1" -o "--rollback_index 1"

    dd if=/dev/random of=1MB_1.2 bs=1MB count=1
    ../tools/avb_sign.sh 1MB_1.2 0 -P $(pwd)/1MB -o --dynamic_partition_size -o "--rollback_index_location 1" -o "--rollback_index 2"

    ./avb_verify -I 1MB_1.1
    ./avb_verify -I 1MB_1.2

    ./avb_verify -U 1MB_1.2 1MB_1.1 ../tools/keys/key.avb && echo PASSED || echo FAILED
    ./avb_verify -U 1MB_1.2 1MB_1.2 ../tools/keys/key.avb && echo PASSED || echo FAILED
    ./avb_verify -U 1MB_1.1 1MB_1.2 ../tools/keys/key.avb && echo FAILED || echo PASSED

    rm -v 1MB_1.1 1MB_1.2
```
Result
```
$     ./avb_verify -U 1MB_1.2 1MB_1.1 ../tools/keys/key.avb && echo PASSED || echo FAILED
PASSED
$     ./avb_verify -U 1MB_1.2 1MB_1.2 ../tools/keys/key.avb && echo PASSED || echo FAILED
PASSED
$     ./avb_verify -U 1MB_1.1 1MB_1.2 ../tools/keys/key.avb && echo FAILED || echo PASSED
avb_slot_verify.c:945: ERROR: 1MB_1.1: Image rollback index is less than the stored rollback index.
./avb_verify verify 1MB_1.1 error 4
PASSED
```