### PR TITLE
ota/tools: Move verification to before installation

### DIFF
--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -84,19 +84,15 @@ def gen_diff_ota_sh(patch_path, bin_list, newpartition_list, args, tmp_folder):
         fd.write(str + "\n")
         user_begin_script.close()
 
-    i = 0
     patch_size_list = []
-    while i < bin_list_cnt:
+    for i in range(bin_list_cnt):
         patch_size_list.append(speed_dict[bin_list[i]] *
                                get_file_size('%s/patch/%spatch' % (tmp_folder, bin_list[i][:-3])))
-        i += 1
 
-    i = 0
     bin_size_list = []
-    while i < bin_list_cnt:
+    for i in range(bin_list_cnt):
         bin_size_list.append(speed_dict[bin_list[i]] *
                              get_file_size('%s/%s' % (args.bin_path[1],bin_list[i])))
-        i += 1
 
     for file in newpartition_list:
         bin_size_list.append(speed_dict[file] * get_file_size('%s/%s' % (args.bin_path[1], file)))
@@ -105,17 +101,13 @@ def gen_diff_ota_sh(patch_path, bin_list, newpartition_list, args, tmp_folder):
     max_progress = 100 - args.user_end_script_progress
     ota_progress_list = []
 
-    i = 0
-    while i < bin_list_cnt:
+    for i in range(bin_list_cnt):
         ota_progress += float(patch_size_list[i] / sum(patch_size_list)) * (max_progress - 30)
         ota_progress_list.append(math.floor(ota_progress))
-        i += 1
 
-    j = 0
-    while j < len(newpartition_list):
+    for j in range(len(newpartition_list)):
         ota_progress += float(bin_size_list[i + j] / sum(bin_size_list)) * (max_progress - 70)
         ota_progress_list.append(math.floor(ota_progress))
-        j += 1
 
     ota_progress_list[-1] = max_progress
     str = \
@@ -131,8 +123,7 @@ then
 ''' % (bin_list[bin_list_cnt - 1])
     fd.write(str)
 
-    i = 0
-    while i < bin_list_cnt:
+    for i in range(bin_list_cnt):
         str = \
 '''
     echo "generate %s"%s
@@ -152,7 +143,6 @@ then
         if i + 1 < bin_list_cnt:
             str += '    setprop ota.progress.next %d\n' % (ota_progress_list[i + 1])
         fd.write(str)
-        i += 1
 
     str = \
 '''
@@ -301,22 +291,18 @@ def gen_full_sh(path_list, bin_list, args, tmp_folder):
         fd.write(str + "\n")
         user_begin_script.close()
 
-    i = 0
     size_list = []
-    while i < path_cnt:
+    for i in range(path_cnt):
         size_list.append(speed_dict[bin_list[i]] *
                          get_file_size('%s/%s' % (args.bin_path[0], bin_list[i])))
-        i += 1
 
     ota_progress = 30.0
     max_progress = 100 - args.user_end_script_progress
     ota_progress_list = []
 
-    i = 0
-    while i < path_cnt:
+    for i in range(path_cnt):
         ota_progress += float(size_list[i] / sum(size_list)) * (max_progress - 30.0)
         ota_progress_list.append(math.floor(ota_progress))
-        i += 1
 
     ota_progress_list[-1] = max_progress
     str = \
@@ -326,8 +312,7 @@ setprop ota.progress.next %d
 ''' % (ota_progress_list[0])
     fd.write(str)
 
-    i = 0
-    while i < path_cnt:
+    for i in range(path_cnt):
         str = ''
         ret = subprocess.Popen("%s info_image --image %s/%s --rollback_index" % (avbtool_path, args.bin_path[0], bin_list[i]), shell=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL);
         idx = ret.communicate()
@@ -360,7 +345,6 @@ setprop ota.progress.current %d
         if i + 1 < path_cnt:
             str += 'setprop ota.progress.next %d\n' % (ota_progress_list[i + 1])
         fd.write(str)
-        i += 1
 
     if args.user_end_script:
         user_end_script = open(args.user_end_script,"r")

--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -312,32 +312,43 @@ def gen_full_sh(path_list, bin_list, args, tmp_folder):
         fd.write(str + "\n")
         user_begin_script.close()
 
-    ota_progress_list = gen_progress_list(30.0, 100 - args.user_end_script_progress, args.bin_path[0], bin_list)
-    str = \
-'''set +e
-setprop ota.progress.current 30
-setprop ota.progress.next %d
-''' % (ota_progress_list[0])
-    fd.write(str)
-
+    verify_list = []
+    verify_path = []
     for i in range(path_cnt):
-        str = ''
         ret = subprocess.Popen("%s info_image --image %s/%s --rollback_index" % (avbtool_path, args.bin_path[0], bin_list[i]), shell=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL);
         idx = ret.communicate()
         if (ret.returncode == 0) and (int(idx[0]) != 0):
             logger.debug("Enabled update verification for %s" % bin_list[i])
-            str += \
+            verify_list.append(bin_list[i])
+            verify_path.append(path_list[i])
+
+    verify_progress_list = gen_progress_list(30.0, 40.0, args.bin_path[0], verify_list)
+    ota_progress_list = gen_progress_list(45.0, 100 - args.user_end_script_progress, args.bin_path[0], bin_list)
+
+    str = \
+'''set +e
+setprop ota.progress.current 30
+setprop ota.progress.next %d
+''' % (verify_progress_list[0])
+    fd.write(str)
+
+    for i in range(len(verify_list)):
+        str = \
 '''
 avb_verify -U /ota/%s %s /etc/key.avb
 if [ $? -ne 0 ]
 then
-    echo "check %s version failed!"%s
+    echo "Check %s version failed!"%s
     setprop ota.progress.current -1
-    exit
+    reboot
 fi
-''' % (bin_list[i], path_list[i], bin_list[i], args.otalog)
+setprop ota.progress.current %d
+''' % (verify_list[i], verify_path[i], verify_list[i], args.otalog, verify_progress_list[i])
+        str += 'setprop ota.progress.next %d\n' % ( verify_progress_list[i + 1] if i + 1 < len(verify_list) else ota_progress_list[0])
+        fd.write(str)
 
-        str += \
+    for i in range(path_cnt):
+        str = \
 '''
 echo "install %s"%s
 time " dd if=/ota/%s of=%s bs=%s verify"

--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -279,6 +279,27 @@ def gen_diff_ota(args):
         logger.info("%s, signature success!" % args.output)
         os.rename(sign_output, args.output)
 
+def gen_progress_list(start, end, path, bin_list):
+    bin_cnt = len(bin_list)
+    ota_progress = start
+    progress_list = []
+    size_list = []
+
+    if end <= start:
+        logger.error("Generate progress list error %d %d" % (start, end))
+        exit(22)
+
+    for i in range(bin_cnt):
+        size_list.append(speed_dict[bin_list[i]] *
+                         get_file_size('%s/%s' % (path, bin_list[i])))
+
+    for i in range(bin_cnt):
+        ota_progress += float(size_list[i] / sum(size_list)) * (end - start)
+        progress_list.append(math.floor(ota_progress))
+
+    progress_list[-1] = end
+    return progress_list
+
 def gen_full_sh(path_list, bin_list, args, tmp_folder):
     path_cnt = len(path_list)
     fd = open('%s/ota.sh' % (tmp_folder),'w')
@@ -291,20 +312,7 @@ def gen_full_sh(path_list, bin_list, args, tmp_folder):
         fd.write(str + "\n")
         user_begin_script.close()
 
-    size_list = []
-    for i in range(path_cnt):
-        size_list.append(speed_dict[bin_list[i]] *
-                         get_file_size('%s/%s' % (args.bin_path[0], bin_list[i])))
-
-    ota_progress = 30.0
-    max_progress = 100 - args.user_end_script_progress
-    ota_progress_list = []
-
-    for i in range(path_cnt):
-        ota_progress += float(size_list[i] / sum(size_list)) * (max_progress - 30.0)
-        ota_progress_list.append(math.floor(ota_progress))
-
-    ota_progress_list[-1] = max_progress
+    ota_progress_list = gen_progress_list(30.0, 100 - args.user_end_script_progress, args.bin_path[0], bin_list)
     str = \
 '''set +e
 setprop ota.progress.current 30


### PR DESCRIPTION
### _WARNING: NOT committed to gerrit yet_
 
 
## Summary
1. Replace "while" with "for in" for loop to make the code more concise.
2. Add function gen_progress_list for generating progress list by binary file size.
3. Move verification to before installation

## Impact
frameworks/system/ota/tools

## Testing
- script
```bash
set -ex

function gen_bin {
  tmp=./imgs
  mkdir -p imgs
  dd if=/dev/random of=${tmp}/vela_${1}.bin bs=${2} count=1
  ./avb_sign.sh ${tmp}/vela_${1}.bin 0 -P /dev/${1} -o --dynamic_partition_size -o "--rollback_index_location ${3}" -o "--rollback_index ${4}"
}

# rollback index greater than zero - upgrade verification enabled
gen_bin tee 1MB 1 1
gen_bin verify1 2MB 1 1
gen_bin verify2 3MB 1 1

# rollback index equal to zero - upgrade verification disabled
gen_bin ap 10MB 1 0
gen_bin no_verify1 20MB 1 0
gen_bin no_verify2 30MB 1 0

./gen_ota_zip.py ./imgs --debug --sign

mkdir -p ./temp
cd ./temp
unzip ../ota.zip
cd -

vi ./temp/ota.sh

#rm -rf ./temp
#rm -rf ./imgs
#rm -vf ota.zip
```
- log

```
+ ./gen_ota_zip.py ./imgs --debug --sign
[DEBUG]add ./imgs/vela_verify2.bin
[DEBUG]add ./imgs/vela_verify1.bin
[DEBUG]add ./imgs/vela_no_verify1.bin
[DEBUG]add ./imgs/vela_ap.bin
[DEBUG]add ./imgs/vela_tee.bin
[DEBUG]add ./imgs/vela_no_verify2.bin
[DEBUG]Enabled update verification for vela_verify2.bin
[DEBUG]Enabled update verification for vela_verify1.bin
[DEBUG]Enabled update verification for vela_tee.bin
[INFO]ota.zip, signature success!
```
```
$ cat temp/ota.sh | grep -E "ota.progress.current|ota.progress.next|avb_verify|dd if" -n | grep -v " -1"
2:setprop ota.progress.current 30
3:setprop ota.progress.next 34
5:avb_verify -U /ota/vela_verify2.bin /dev/verify2 /etc/key.avb
12:setprop ota.progress.current 34
13:setprop ota.progress.next 38
15:avb_verify -U /ota/vela_verify1.bin /dev/verify1 /etc/key.avb
22:setprop ota.progress.current 38
23:setprop ota.progress.next 40
25:avb_verify -U /ota/vela_tee.bin /dev/tee /etc/key.avb
32:setprop ota.progress.current 40
33:setprop ota.progress.next 47
36:time " dd if=/ota/vela_verify2.bin of=/dev/verify2 bs=32768 verify"
42:setprop ota.progress.current 47
43:setprop ota.progress.next 49
46:time " dd if=/ota/vela_verify1.bin of=/dev/verify1 bs=32768 verify"
52:setprop ota.progress.current 49
53:setprop ota.progress.next 65
56:time " dd if=/ota/vela_no_verify1.bin of=/dev/no_verify1 bs=32768 verify"
62:setprop ota.progress.current 65
63:setprop ota.progress.next 74
66:time " dd if=/ota/vela_ap.bin of=/dev/ap bs=32768 verify"
72:setprop ota.progress.current 74
73:setprop ota.progress.next 75
76:time " dd if=/ota/vela_tee.bin of=/dev/tee bs=32768 verify"
82:setprop ota.progress.current 75
83:setprop ota.progress.next 100
86:time " dd if=/ota/vela_no_verify2.bin of=/dev/no_verify2 bs=32768 verify"
92:setprop ota.progress.current 100
```