### PR TITLE
avb_verify: Ignore partition error during upgrade

### DIFF
--- a/verify/avb_verify.c
+++ b/verify/avb_verify.c
@@ -230,9 +230,12 @@ int avb_verify(struct avb_params_t* params)
             AVB_HASHTREE_ERROR_MODE_RESTART_AND_INVALIDATE,
             &slot_data[n]);
 
-        if (ret != AVB_SLOT_VERIFY_RESULT_OK || !slot_data[n] || (!n && !params->image))
+        if (!params->image)
             goto out;
     }
+
+    if (!slot_data[0] || !slot_data[1])
+        goto out;
 
     for (n = 0; n < AVB_MAX_NUMBER_OF_ROLLBACK_INDEX_LOCATIONS; n++) {
         if (slot_data[1]->rollback_indexes[n] < slot_data[0]->rollback_indexes[n]) {


### PR DESCRIPTION
> # **Not committed to Gerrit yet**
## Summary
Ignore partition verfication error during upgrade verfication, because there may be abnormal exit during non-A/B upgrade.
## Impact
- frameworks/system/ota
## Testing
Test commands
```bash
dd if=/dev/random of=1MB_1.1 bs=1MB count=1
../tools/avb_sign.sh 1MB_1.1 0 -P ./1MB_1.1 -o --dynamic_partition_size -o "--rollback_index_location 1" -o "--rollback_index 1"
dd if=/dev/random of=1MB_1.2 bs=1MB count=1
../tools/avb_sign.sh 1MB_1.2 0 -P ./1MB_1.2 -o --dynamic_partition_size -o "--rollback_index_location 1" -o "--rollback_index 2"

./avb_verify -I ./1MB_1.1
./avb_verify -I ./1MB_1.2

echo -n "1. Upgrade test: "
./avb_verify -U ./1MB_1.2 ./1MB_1.1 ../tools/keys/key.avb && echo PASSED || echo FAILED

echo -n "2. Same version test: "
./avb_verify -U ./1MB_1.2 ./1MB_1.2 ../tools/keys/key.avb && echo PASSED || echo FAILED

echo -n "3. Downgrade test: "
./avb_verify -U ./1MB_1.1 ./1MB_1.2 ../tools/keys/key.avb && echo FAILED || echo PASSED

dd if=/dev/random of=./1MB_1.1 bs=512K count=1 conv=notrunc

echo -n "4. Broken partition verification test: "
./avb_verify ./1MB_1.1 ../tools/keys/key.avb && echo FAILED || echo PASSED

echo -n "5. Broken partition upgrade test: "
./avb_verify -U ./1MB_1.2 ./1MB_1.1 ../tools/keys/key.avb && echo PASSED || echo FAILED

rm -v 1MB_1.1 1MB_1.2
```
Test results
```bash
+ echo -n '1. Upgrade test: '
1. Upgrade test: + ./avb_verify -U ./1MB_1.2 ./1MB_1.1 ../tools/keys/key.avb
+ echo PASSED
PASSED
+ echo -n '2. Same version test: '
2. Same version test: + ./avb_verify -U ./1MB_1.2 ./1MB_1.2 ../tools/keys/key.avb
+ echo PASSED
PASSED
+ echo -n '3. Downgrade test: '
3. Downgrade test: + ./avb_verify -U ./1MB_1.1 ./1MB_1.2 ../tools/keys/key.avb
./avb_verify error 4
+ echo PASSED
PASSED
+ dd if=/dev/random of=./1MB_1.1 bs=512K count=1 conv=notrunc
1+0 records in
1+0 records out
524288 bytes (524 kB, 512 KiB) copied, 0.00115562 s, 454 MB/s
+ echo -n '4. Broken partition verification test: '
4. Broken partition verification test: + ./avb_verify ./1MB_1.1 ../tools/keys/key.avb
avb_slot_verify.c:526: ERROR: ./1MB_1.1: Hash of data does not match digest in descriptor.
./avb_verify error 3
+ echo PASSED
PASSED
+ echo -n '5. Broken partition upgrade test: '
5. Broken partition upgrade test: + ./avb_verify -U ./1MB_1.2 ./1MB_1.1 ../tools/keys/key.avb
avb_slot_verify.c:526: ERROR: ./1MB_1.1: Hash of data does not match digest in descriptor.
+ echo PASSED
PASSED
```