### PR TITLE
ota/tools: Check if verify list is null

### DIFF
--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -297,7 +297,9 @@ def gen_progress_list(start, end, path, bin_list):
         ota_progress += float(size_list[i] / sum(size_list)) * (end - start)
         progress_list.append(math.floor(ota_progress))
 
-    progress_list[-1] = end
+    if len(progress_list) != 0:
+        progress_list[-1] = end
+
     return progress_list
 
 def gen_full_sh(path_list, bin_list, args, tmp_folder):
@@ -329,7 +331,7 @@ def gen_full_sh(path_list, bin_list, args, tmp_folder):
 '''set +e
 setprop ota.progress.current 30
 setprop ota.progress.next %d
-''' % (verify_progress_list[0])
+''' % (verify_progress_list[0] if len(verify_list) != 0 else ota_progress_list[0])
     fd.write(str)
 
     for i in range(len(verify_list)):


### PR DESCRIPTION
> Pick from Gerrit (Change-Id: I781a6ec4d73607153d702be9f0cfa6c4e3e09501).

## Summary
Check if the verify list is empty to prevent array out of bounds.
 
Error log when no image is signed(The `verify_list` is empty):
```
File "./gen_ota_zip.py", line 288, in gen_progress_list
  progress_list[-1] = end
IndexError: list assignment index out of range
```

## Impact
ota/tools.

## Testing
1. Selftest passed
```bash
# The vela_quickapp.bin is not AVB signed
$ ls test/
vela_quickapp.bin

# No signed image in directory "test"
$ ./gen_ota_zip.py --sign ./test/
[INFO]ota.zip, signature success!
```
2. CI