### PR TITLE
Add assert and summarize spent time for verify

### DIFF
--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -337,7 +337,8 @@ setprop ota.progress.next %d
     for i in range(len(verify_list)):
         str = \
 '''
-avb_verify -U /ota/%s %s /etc/key.avb
+echo "verify %s"%s
+time "avb_verify -U /ota/%s %s /etc/key.avb"
 if [ $? -ne 0 ]
 then
     echo "Check %s version failed!"%s
@@ -345,7 +346,7 @@ then
     reboot
 fi
 setprop ota.progress.current %d
-''' % (verify_list[i], verify_path[i], verify_list[i], args.otalog, verify_progress_list[i])
+''' % (verify_list[i], args.otalog, verify_list[i], verify_path[i], verify_list[i], args.otalog, verify_progress_list[i])
         str += 'setprop ota.progress.next %d\n' % ( verify_progress_list[i + 1] if i + 1 < len(verify_list) else ota_progress_list[0])
         fd.write(str)
 

--- a/verify/zip_verify.c
+++ b/verify/zip_verify.c
@@ -243,6 +243,7 @@ static int verify_signature(data_block_t* pubkey, data_block_t* raw_data, data_b
     avb_sha256_update(
         &sha256_ctx, raw_data->data, raw_data->length);
     computed_hash = avb_sha256_final(&sha256_ctx);
+    assert_res(computed_hash != NULL, "Calculating MD failed!");
 
     res = !avb_rsa_verify(pubkey->data, pubkey->length,
         signature->data, signature->length,
@@ -414,7 +415,7 @@ static int verify_app(const char* app_path, const char* cert_path, size_t commen
     res = verify_signature(&avbkey, &signature_info.signed_data,
         &signature_info.signatures_content);
     free(avbkey.data);
-    assert_res(res == 0);
+    assert_res(res == 0, "Verify signature failed!");
 
     // Compare whether the app summary is consistent with the signature block summary
     res = verify_digest(app_path, app_block, &signature_info.one_digest);


### PR DESCRIPTION
> ### Pick from Gerrit 5475925 and 5496108
## Summary
Add assert for "zip_verify" when calculating MD failed, and summarize spent time for "avb_verify".
1. Assert if "zip_verify" calculating MD failed
2. Summarize "avb_verify" spent time

## Impact
system/ota/verify

## Testing
1. Selftest
```
verify vela_tee.bin

2.5296 sec
```
2. CI

