### PR TITLE
ota: Add precheck for diff apply

### DIFF
--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -99,14 +99,15 @@ def gen_diff_ota_sh(patch_path, bin_list, newpartition_list, args, tmp_folder):
 
     ota_progress = 30.0
     max_progress = 100 - args.user_end_script_progress
+    gen_progress = (max_progress - ota_progress) * float(sum(bin_size_list[:bin_list_cnt]) / sum (bin_size_list))
     ota_progress_list = []
 
     for i in range(bin_list_cnt):
-        ota_progress += float(patch_size_list[i] / sum(patch_size_list)) * (max_progress - 30)
+        ota_progress += float(patch_size_list[i] / sum(patch_size_list)) * gen_progress
         ota_progress_list.append(math.floor(ota_progress))
 
     for j in range(len(newpartition_list)):
-        ota_progress += float(bin_size_list[i + j] / sum(bin_size_list)) * (max_progress - 70)
+        ota_progress += float(bin_size_list[i + j] / sum(bin_size_list)) * (max_progress - ota_progress - gen_progress)
         ota_progress_list.append(math.floor(ota_progress))
 
     ota_progress_list[-1] = max_progress

--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -126,7 +126,7 @@ if [ $? -ne 0 ]
 then
     echo "ddelta_apply %s failed"%s
     setprop ota.progress.current -1
-    exit
+    reboot
 fi
 
 setprop ota.progress.current %d

--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -103,12 +103,11 @@ def gen_diff_ota_sh(patch_path, bin_list, newpartition_list, args, tmp_folder):
     ota_progress_list = []
 
     for i in range(bin_list_cnt):
-        ota_progress += float(patch_size_list[i] / sum(patch_size_list)) * gen_progress
-        ota_progress_list.append(math.floor(ota_progress))
+        ota_progress_list.insert(len(ota_progress_list) // 2, math.floor(ota_progress + float(sum(patch_size_list[:i + 1]) / sum(patch_size_list)) * gen_progress * 0.1))
+        ota_progress_list.append(math.floor(ota_progress + gen_progress * 0.1 + float(sum(patch_size_list[:i + 1]) / sum(patch_size_list)) * gen_progress * 0.9))
 
     for j in range(len(newpartition_list)):
-        ota_progress += float(bin_size_list[i + j] / sum(bin_size_list)) * (max_progress - ota_progress - gen_progress)
-        ota_progress_list.append(math.floor(ota_progress))
+        ota_progress_list.append(math.floor(ota_progress + gen_progress + float(sum(bin_size_list[bin_list_cnt:bin_list_cnt + j + 1]) / sum(bin_size_list[bin_list_cnt:])) * (max_progress - ota_progress - gen_progress)))
 
     ota_progress_list[-1] = max_progress
     str = \
@@ -118,11 +117,12 @@ setprop ota.progress.next %d
 ''' % (ota_progress_list[0])
     fd.write(str)
 
-    for i in range(bin_list_cnt):
+    bin_list_cnt *= 2
+    for i, j in zip(list(range(bin_list_cnt // 2)) * 2, range(bin_list_cnt)):
         str = \
 '''
 echo "generate %s"%s
-time "ddelta_apply %s %s/ /ota/%spatch"
+time "ddelta_apply %s %s/ /ota/%spatch %s"
 if [ $? -ne 0 ]
 then
     echo "ddelta_apply %s failed"%s
@@ -132,11 +132,11 @@ fi
 
 setprop ota.progress.current %d
 ''' % (bin_list[i], args.otalog,
-       patch_path[i], args.ota_tmp, bin_list[i][:-3],
+       patch_path[i], args.ota_tmp, bin_list[i][:-3], "precheck" if j < bin_list_cnt // 2 else "",
        bin_list[i][:-4], args.otalog,
-       ota_progress_list[i])
-        if i + 1 < bin_list_cnt:
-            str += 'setprop ota.progress.next %d\n' % (ota_progress_list[i + 1])
+       ota_progress_list[j])
+        if j + 1 < bin_list_cnt:
+            str += 'setprop ota.progress.next %d\n' % (ota_progress_list[j + 1])
         fd.write(str)
 
     i = 0

--- a/tools/gen_ota_zip.py
+++ b/tools/gen_ota_zip.py
@@ -117,38 +117,26 @@ setprop ota.progress.next %d
 ''' % (ota_progress_list[0])
     fd.write(str)
 
-    str = \
-'''if [ ! -e /ota/%s ]
-then
-''' % (bin_list[bin_list_cnt - 1])
-    fd.write(str)
-
     for i in range(bin_list_cnt):
         str = \
 '''
-    echo "generate %s"%s
-    time "ddelta_apply %s %s/ /ota/%spatch"
-    if [ $? -ne 0 ]
-    then
-        echo "ddelta_apply %s failed"%s
-        setprop ota.progress.current -1
-        exit
-    fi
+echo "generate %s"%s
+time "ddelta_apply %s %s/ /ota/%spatch"
+if [ $? -ne 0 ]
+then
+    echo "ddelta_apply %s failed"%s
+    setprop ota.progress.current -1
+    exit
+fi
 
-    setprop ota.progress.current %d
+setprop ota.progress.current %d
 ''' % (bin_list[i], args.otalog,
        patch_path[i], args.ota_tmp, bin_list[i][:-3],
        bin_list[i][:-4], args.otalog,
        ota_progress_list[i])
         if i + 1 < bin_list_cnt:
-            str += '    setprop ota.progress.next %d\n' % (ota_progress_list[i + 1])
+            str += 'setprop ota.progress.next %d\n' % (ota_progress_list[i + 1])
         fd.write(str)
-
-    str = \
-'''
-fi
-'''
-    fd.write(str)
 
     i = 0
     for file in newpartition_list:


### PR DESCRIPTION
> # Pick from Gerrit
## Summary
1. ota: remove this redundant judgment
2. ota: need reboot and retry if patch failed
3. ota: Fix error that progress exceeds 100
4. ota: Add precheck for diff apply

### Time spent
|Binary | Precheck (sec) | Apply (sec)|
|--|--:|--:|
|vela_ap.bin        |0.6540    |53.5653|                                                                                                                                                
|vela_audio.bin     |0.1931    |14.5435|
|vela_cp.bin        |0.4005    |31.8204|
|vela_quickapp.bin  |0.2488    | 1.9555|
|vela_tee.bin       |0.0944    | 5.9005|
|vela_vendor.bin    |1.0311    | 9.8397|
## Impact
- tools/gen_ota_zip.py

## Testing
1. Self test passed
```Makefile
all:

clean:
        rm -rvf ./ddelta_generate ./ddelta_apply
        rm -rvf ./after.crc32 ./before.crc32
        rm -rvf ./old/vela_ap*.hexdump
        rm -rvf ./new/vela_ap*.hexdump
        rm -rvf ./ap.patch
        rm -rvf ./*.tmp.log
        rm -rvf ./ap.patch.*
        rm -rvf ap.patch.*.zip

.crc32.before:
        crc32 old/vela_ap.bin* new/vela_ap.bin* ap.patch* > before.crc32
.crc32.after:
        crc32 old/vela_ap.bin* new/vela_ap.bin* ap.patch* > after.crc32

build_ddelta:
        make -C ../../../../external/ddelta/ddelta -f Makefile > $@.tmp.log 2>&1
        mv ../../../../external/ddelta/ddelta/ddelta_generate .
        mv ../../../../external/ddelta/ddelta/ddelta_apply .

dd_files:
        cp old/202506100438/images/ap/vela_ap.bin ./old
        cp new/202506150438/images/ap/vela_ap.bin ./new
        
        dd if=./old/vela_ap.bin of=./old/vela_ap.bin0 bs=524288 count=1
        dd if=./old/vela_ap.bin of=./old/vela_ap.bin1 bs=524288 count=1 skip=1
        dd if=./new/vela_ap.bin of=./new/vela_ap.bin0 bs=524288 count=1
        dd if=./new/vela_ap.bin of=./new/vela_ap.bin1 bs=524288 count=1 skip=1
        
        dd if=/dev/zero of=old/vela_ap.bin_zero bs=10485760 count=1
        
        hexdump -v -e '"%07.7_ax  " 16/1 "%02x " "\n"' ./old/vela_ap.bin > ./old/vela_ap.before.hexdump
        hexdump -v -e '"%07.7_ax  " 16/1 "%02x " "\n"' ./new/vela_ap.bin > ./new/vela_ap.before.hexdump


#
#
#

generate: ap.patch.blk5MB
apply: apply.normal

ap.patch.blk1KB: build_ddelta
        make dd_files > dd.tmp.log 2>&1
        rm -vf $@.zip
        ./ddelta_generate old/vela_ap.bin new/vela_ap.bin $@ 1024 > $@.tmp.log 2>&1
        zip $@.zip $@                                                                                                                                                                   
        ln -sf $@ ap.patch

ap.patch.blk512KB: build_ddelta
        make dd_files > dd.tmp.log 2>&1
        rm -vf $@.zip
        ./ddelta_generate old/vela_ap.bin new/vela_ap.bin $@ 524288 > $@.tmp.log 2>&1
        zip $@.zip $@
        ln -sf $@ ap.patch

ap.patch.blk5MB: build_ddelta
        make dd_files > dd.tmp.log 2>&1
        rm -vf $@.zip
        ./ddelta_generate old/vela_ap.bin new/vela_ap.bin $@ 5242880 > $@.tmp.log 2>&1
        zip $@.zip $@
        ln -sf $@ ap.patch

ap.patch.blknone: build_ddelta
        make dd_files > dd.tmp.log 2>&1
        rm -vf $@.zip
        ./ddelta_generate old/vela_ap.bin new/vela_ap.bin $@ > $@.tmp.log 2>&1
        zip $@.zip $@
        ln -sf $@ ap.patch

apply.normal: build_ddelta .crc32.before
        ./ddelta_apply ./old/vela_ap.bin ./ ./ap.patch > $@.tmp.log 2>&1
        hexdump -v -e '"%07.7_ax  " 16/1 "%02x " "\n"' ./old/vela_ap.bin > ./old/vela_ap.after.hexdump
        make .crc32.after

apply.test: build_ddelta .crc32.before
        ./ddelta_apply ./old/vela_ap.bin ./ ./ap.patch test > $@.tmp.log 2>&1
        hexdump -v -e '"%07.7_ax  " 16/1 "%02x " "\n"' ./old/vela_ap.bin > ./old/vela_ap.after.hexdump
        make .crc32.after

#
#
#

corrupt_block:
        # corrupt block?
        # Cannot apply patch: -4(2)
        make generate
        dd if=/dev/zero of=old/vela_ap.bin bs=16 seek=2 count=2 conv=notrunc
        make apply
```
2. CI
